### PR TITLE
chore(dependabot): ignore sample-app paths; document intentional pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,23 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
 
+  # Sample apps intentionally pin vulnerable dependency versions to
+  # demonstrate SBOM / OSS-attribution generation. Ignore all updates
+  # so Dependabot does not open PRs for these demo fixtures.
+  - package-ecosystem: "pip"
+    directory: "/pypi/vulnerable-sample-app"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+
+  - package-ecosystem: "maven"
+    directory: "/maven/sample-app"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ Here are some examples for common languages and package managers on how to creat
 * Projects using Maven
 * Projects using Gradle
 * Projects using PyPI
+
+## Note on sample apps
+
+The sample apps under `pypi/vulnerable-sample-app/` and `maven/sample-app/` intentionally pin known-vulnerable dependency versions (e.g. `Django==1.11.29`, `requests==2.19.1`, `PyYAML==3.12`). They exist as fixtures to demonstrate SBOM and OSS-attribution generation against realistic, version-locked manifests — not as code intended to be deployed. Dependabot is configured to skip update PRs for these paths; security alerts may still surface in the dependency graph and are kept as documentation of the demo's vulnerability surface.


### PR DESCRIPTION
## Summary

- Add Dependabot `ignore` blocks for `pypi/vulnerable-sample-app/` (pip) and `maven/sample-app/` (maven) so Dependabot does not open update PRs against the intentionally-vulnerable demo fixtures.
- Add a short README note explaining that these sample apps pin known-vulnerable versions (e.g. `Django==1.11.29`, `requests==2.19.1`, `PyYAML==3.12`) on purpose, to demonstrate SBOM / OSS-attribution generation.

## Why

The repo's primary purpose is demonstrating Legal Notices / OSPI generation from realistic, version-locked manifests. Upgrading the pinned versions would defeat the demo. Dependabot was quiet about these paths today (root `directory: "/"` doesn't include them), but this change makes the intent explicit and silences any future automated PRs that target the sample app trees.

## Notes

- **No alerts dismissed.** The 15 open Dependabot alerts (3 critical, 4 high, 8 moderate) remain as documentation of the demo's vulnerability surface.
- No code dependency changes; configuration + docs only.

## Test plan

- [ ] Confirm `.github/dependabot.yml` parses (GitHub validates on push).
- [ ] Verify no new Dependabot update PRs target the ignored directories on the next scheduled run.